### PR TITLE
General: add renovate config file.

### DIFF
--- a/standards/renovate.json
+++ b/standards/renovate.json
@@ -1,0 +1,13 @@
+{
+	"extends": [
+		"config:base"
+	],
+	"labels": [
+		"[Type] Janitorial",
+		"[Status] Needs Review"
+	],
+	"prHourlyLimit": 1,
+	"supportPolicy": [
+		"lts_latest"
+	]
+}


### PR DESCRIPTION
What would you say about adding a default `renovate.json` file now that the labels are also part of the standards?