### PR TITLE
Labels: Remove the Dotcom Merge label from the list of default labels

### DIFF
--- a/github/labels.json
+++ b/github/labels.json
@@ -201,11 +201,6 @@
       "description": "When a feature is broken and / or not performing as intended"
     },
     {
-      "name": "[Type] Dotcom Merge",
-      "color": "bfdadc",
-      "description": "Is this PR bringing a WordPress.com commit to your plugin?"
-    },
-    {
       "name": "[Type] Duplicate",
       "color": "c7def8",
       "description": ""


### PR DESCRIPTION
This label is too specific to Jetpack; it does not need to be part of the standards.

Reported here:
https://github.com/Automattic/vaultpress/pull/3#discussion_r286153320