### PR TITLE
Set up defaults for master branch protection.

### DIFF
--- a/github/settings.json
+++ b/github/settings.json
@@ -6,5 +6,19 @@
     "allow_squash_merge": true,
     "allow_merge_commit": false,
     "allow_rebase_merge": false
-  }
+  },
+  "branches": [
+    {
+      "name": "master",
+      "required_status_checks": null,
+      "enforce_admins": true,
+      "required_pull_request_reviews": {
+        "dismissal_restrictions": {},
+        "dismiss_stale_reviews": true,
+        "require_code_owner_reviews": false,
+        "required_approving_review_count": 1
+      },
+      "restrictions": null
+    }
+  ]
 }

--- a/github/settings.json
+++ b/github/settings.json
@@ -9,7 +9,7 @@
   },
   "branches": [
     {
-      "name": "master",
+      "name": "trunk",
       "required_status_checks": null,
       "enforce_admins": true,
       "required_pull_request_reviews": {


### PR DESCRIPTION
This PR introduces a new set of default repo settings, allowing us to protect branches (here the `master` branch) when we don't want anyone to push to it directly.

The settings in that PR will generate the following branch protection settings:

<img width="801" alt="screenshot 2019-05-21 at 23 45 48" src="https://user-images.githubusercontent.com/426388/58133317-e2116080-7c23-11e9-8e4f-0bb4f7aa0d8d.png">

Related diff: D28521-code

This can be tested via the webhook.